### PR TITLE
Fix issue with conditions at glacier contour not well set

### DIFF
--- a/code/simulate_bed_with_sgs.py
+++ b/code/simulate_bed_with_sgs.py
@@ -228,8 +228,9 @@ idx_contour = np.where(final_mask.data)
 res_contour = np.ones(np.size(idx_contour, 1)) * 0.001
 res = np.concatenate((res, res_contour))
 res_log = np.concatenate((res_log, np.log(res_contour)))
-zbed_x = np.concatenate((zbed_x, idx_contour[0]))
-zbed_y = np.concatenate((zbed_y, idx_contour[1]))
+grid_x, grid_y = H_model.coords()
+zbed_x = np.concatenate((zbed_x, grid_x[idx_contour]))
+zbed_y = np.concatenate((zbed_y, grid_y[idx_contour]))
 
 # -- Run simulations --
 


### PR DESCRIPTION
There was an issue in the previous version of the SGS. The observations of H=0 at the glacier contour were set to the pixel index and not actual position, so this was not properly taken into account. This is easily fixed ([2504349](https://github.com/adehecq/argentiere_pleiades_smb/pull/4/commits/25043496fca0b07a1c2711af0383061ab901cf80)).

**However**, adding this constraint results in quite longer computation times and most areas with no observations fall below 1 m thickness in the log configuration. See figure below (downsampling of 5):
![simu_samples](https://github.com/adehecq/argentiere_pleiades_smb/assets/3285905/e948dbad-b77a-4a28-bec7-8e2cf709a65d)

The issue does not occur when not using the log, but then many areas near the edges have < 0 m thickness.
![simu_samples](https://github.com/adehecq/argentiere_pleiades_smb/assets/3285905/0e40c96b-495c-4f18-8a4e-d691fdbe7249)

![temp](https://github.com/adehecq/argentiere_pleiades_smb/assets/3285905/6e8ae23c-d6b8-4da8-9928-9029539baae9)
